### PR TITLE
Fix image width and padding in NavBar component

### DIFF
--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -48,7 +48,7 @@ const NavBar = () => {
       <div className="flex flex-col items-center">
         {/* Project Icon */}
         <a href="/" className="flex items-center flex-col">
-          <img src={icon} alt="Project Icon" className="w-full h-12 mr-2 " />
+          <img src={icon} alt="Project Icon" className="w-auto h-12 mr-2 " />
         </a>
       </div>
 

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -48,7 +48,11 @@ const NavBar = () => {
       <div className="flex flex-col items-center">
         {/* Project Icon */}
         <a href="/" className="flex items-center flex-col">
-          <img src={icon} alt="Project Icon" className="w-auto h-12 mr-2 " />
+          <img
+            src={icon}
+            alt="Project Icon"
+            className="w-auto h-12 mr-2 px-2 "
+          />
         </a>
       </div>
 


### PR DESCRIPTION
This pull request fixes the image width in the NavBar component and adds additional padding. The image width was previously set to 100% which caused it to stretch. With this change, the image now adjusts its width automatically. Additionally, padding has been added to improve the spacing between elements in the NavBar component.
