### PR TITLE
Add placeholder for email input field

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -23,6 +23,7 @@ function Login () {
           type="email"
           id="email"
           name="email"
+          placeholder="johndoe@gmail.com"
           className="border border-gray-400 rounded-md p-2 w-full mb-4"
           required
         />


### PR DESCRIPTION
This pull request adds a placeholder for the email input field in the Login component. The placeholder text is set to "johndoe@gmail.com".