### PR TITLE
Create Age Check in Product Page

### DIFF
--- a/frontend/src/components/AgeVerification.jsx
+++ b/frontend/src/components/AgeVerification.jsx
@@ -1,0 +1,53 @@
+import React, { useState, useEffect } from 'react';
+
+function AgeVerificationPopup() {
+  const [showPopup, setShowPopup] = useState(false);
+
+  useEffect(() => {
+    const isConfirmed = localStorage.getItem('isOver18');
+    if (!isConfirmed) {
+      setTimeout(() => {
+        setShowPopup(true);
+      }, 5000);
+    }
+  }, []);
+
+  const handleConfirm = () => {
+    localStorage.setItem('isOver18', true);
+    setShowPopup(false);
+  };
+  const handleDeny = () => {
+    window.location.href = 'https://www.google.com';
+  }
+
+  return (
+    <div
+      className={`fixed top-0 left-0 w-full h-screen z-50 flex items-center justify-center bg-gray-900/75 transition duration-150 ease-in-out ${showPopup ? 'opacity-100' : 'opacity-0'}`}
+    >
+      <div className="bg-white rounded-lg shadow-lg max-w-md mx-auto p-8 text-center">
+        <h2 className="text-3xl font-sans mb-4">Age Verification</h2>
+        <p className="text-lg leading-relaxed mb-2">
+          Before you proceed, we need to ensure you're above 18 years old. This
+          content may contain mature themes or restricted materials, so we want
+          to be responsible and compliant with age verification regulations.
+        </p>
+        <p className="text-lg leading-relaxed mb-4">
+          If you're over 18 and comfortable with the content, please click "Yes"
+          to continue. Otherwise, please click "No" to be redirected to our
+          general audience information.
+        </p>
+        <div className="flex items-center justify-center mt-8">
+          <button
+            onClick={handleConfirm}
+            className="btn btn-primary mr-4 rounded-lg border border-gray-400 sm:p-1 p-2 hover:bg-green-800"
+          >
+            Yes, I'm Over 18
+          </button>
+          <button onClick={handleDeny} className="btn btn-secondary rounded-lg border border-gray-400 sm:p-1 p-2 hover:bg-red-800">No, I'm Not 18</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AgeVerificationPopup;

--- a/frontend/src/components/INDEX.js
+++ b/frontend/src/components/INDEX.js
@@ -9,3 +9,4 @@ export { default as Subscribe } from "../components/Subscribe";
 export { default as FAQ } from "../components/FAQ";
 export { default as RelatedDrinks } from "../components/RelatedDrinks";
 export {default as PrivateRoute} from "../components/PrivateRoute";
+export {default as AgeVerificationPopup} from "../components/AgeVerification";

--- a/frontend/src/pages/Product.jsx
+++ b/frontend/src/pages/Product.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { getDrink } from "../services/api";
 import { useParams } from "react-router-dom/cjs/react-router-dom.min";
-import { Drink, FAQ, RelatedDrinks } from "../components/INDEX";
+import { Drink, FAQ, RelatedDrinks, AgeVerificationPopup } from "../components/INDEX";
 
 function Product() {
   const [relatedDrinks, setRelatedDrinks] = useState([]);
@@ -24,6 +24,7 @@ function Product() {
       <Drink drink={drink} />
       <FAQ />
       <RelatedDrinks relatedDrinks={relatedDrinks} />
+      <AgeVerificationPopup />
     </div>
   );
 }


### PR DESCRIPTION
This pull request adds an age verification popup to the product page. Before viewing a product, users will be asked to confirm if they are above 18 years old. The popup includes a card with a different background, centered elements, a header text, "Are you up to 18?" question, YES and NO buttons, and a checklist for users who never want to see the popup again.

Fixes #46